### PR TITLE
Restructure survey with expanded needs descriptions

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -7,7 +7,9 @@ h1.logo span:nth-child(3){color:#60a5fa;}
 a.button,button{display:inline-block;padding:12px 18px;border-radius:8px;text-decoration:none;font-weight:bold;
  background:linear-gradient(135deg,#4ade80,#60a5fa);color:#000;margin:10px 0;cursor:pointer;}
 a.button.secondary{background:none;border:1px solid #aaa;color:#eee;}
-.need{margin:15px 0;padding:10px;border:1px solid #333;border-radius:8px;}
+.need{margin:15px 0;padding:16px;border:1px solid #333;border-radius:8px;background:rgba(17,25,40,0.6);}
+.need h3{margin:0 0 0.4em;font-size:1.2em;color:#fff;}
+.need-description{margin:0 0 1em;color:#cbd5f5;line-height:1.5;}
 .scale label{margin-right:8px;cursor:pointer;}
 .notice{background:#223;padding:10px;border-radius:6px;margin-top:15px;}
 .success{background:#252;color:#afa;}

--- a/survey.html
+++ b/survey.html
@@ -11,7 +11,226 @@
   <h1 class="logo"><span>LIVE</span><span>LEARN</span><span>DO</span></h1>
   <p style="text-align:center">Rate each need from 1 (not met) to 5 (fully met).</p>
   <form id="surveyForm">
-<div class='need'><h3>Connection</h3><div class='scale'><label><input type='radio' name='connection' value='1'>1</label><label><input type='radio' name='connection' value='2'>2</label><label><input type='radio' name='connection' value='3'>3</label><label><input type='radio' name='connection' value='4'>4</label><label><input type='radio' name='connection' value='5'>5</label></div></div><div class='need'><h3>Respect</h3><div class='scale'><label><input type='radio' name='respect' value='1'>1</label><label><input type='radio' name='respect' value='2'>2</label><label><input type='radio' name='respect' value='3'>3</label><label><input type='radio' name='respect' value='4'>4</label><label><input type='radio' name='respect' value='5'>5</label></div></div><div class='need'><h3>Understanding</h3><div class='scale'><label><input type='radio' name='understanding' value='1'>1</label><label><input type='radio' name='understanding' value='2'>2</label><label><input type='radio' name='understanding' value='3'>3</label><label><input type='radio' name='understanding' value='4'>4</label><label><input type='radio' name='understanding' value='5'>5</label></div></div><div class='need'><h3>Safety</h3><div class='scale'><label><input type='radio' name='safety' value='1'>1</label><label><input type='radio' name='safety' value='2'>2</label><label><input type='radio' name='safety' value='3'>3</label><label><input type='radio' name='safety' value='4'>4</label><label><input type='radio' name='safety' value='5'>5</label></div></div><div class='need'><h3>Trust</h3><div class='scale'><label><input type='radio' name='trust' value='1'>1</label><label><input type='radio' name='trust' value='2'>2</label><label><input type='radio' name='trust' value='3'>3</label><label><input type='radio' name='trust' value='4'>4</label><label><input type='radio' name='trust' value='5'>5</label></div></div><div class='need'><h3>Autonomy</h3><div class='scale'><label><input type='radio' name='autonomy' value='1'>1</label><label><input type='radio' name='autonomy' value='2'>2</label><label><input type='radio' name='autonomy' value='3'>3</label><label><input type='radio' name='autonomy' value='4'>4</label><label><input type='radio' name='autonomy' value='5'>5</label></div></div><div class='need'><h3>Love</h3><div class='scale'><label><input type='radio' name='love' value='1'>1</label><label><input type='radio' name='love' value='2'>2</label><label><input type='radio' name='love' value='3'>3</label><label><input type='radio' name='love' value='4'>4</label><label><input type='radio' name='love' value='5'>5</label></div></div><div class='need'><h3>Belonging</h3><div class='scale'><label><input type='radio' name='belonging' value='1'>1</label><label><input type='radio' name='belonging' value='2'>2</label><label><input type='radio' name='belonging' value='3'>3</label><label><input type='radio' name='belonging' value='4'>4</label><label><input type='radio' name='belonging' value='5'>5</label></div></div><div class='need'><h3>Growth</h3><div class='scale'><label><input type='radio' name='growth' value='1'>1</label><label><input type='radio' name='growth' value='2'>2</label><label><input type='radio' name='growth' value='3'>3</label><label><input type='radio' name='growth' value='4'>4</label><label><input type='radio' name='growth' value='5'>5</label></div></div><div class='need'><h3>Contribution</h3><div class='scale'><label><input type='radio' name='contribution' value='1'>1</label><label><input type='radio' name='contribution' value='2'>2</label><label><input type='radio' name='contribution' value='3'>3</label><label><input type='radio' name='contribution' value='4'>4</label><label><input type='radio' name='contribution' value='5'>5</label></div></div><div class='need'><h3>Purpose/Meaning</h3><div class='scale'><label><input type='radio' name='purpose-meaning' value='1'>1</label><label><input type='radio' name='purpose-meaning' value='2'>2</label><label><input type='radio' name='purpose-meaning' value='3'>3</label><label><input type='radio' name='purpose-meaning' value='4'>4</label><label><input type='radio' name='purpose-meaning' value='5'>5</label></div></div><div class='need'><h3>Play/Rest</h3><div class='scale'><label><input type='radio' name='play-rest' value='1'>1</label><label><input type='radio' name='play-rest' value='2'>2</label><label><input type='radio' name='play-rest' value='3'>3</label><label><input type='radio' name='play-rest' value='4'>4</label><label><input type='radio' name='play-rest' value='5'>5</label></div></div>
+    <div class="need">
+      <h3>Nurturance</h3>
+      <p class="need-description">The need to care for and be cared for by others. Nurturance involves both giving and receiving emotional support, which fosters resilience, empathy, and deeper connections. It plays a critical role in emotional well-being, helping individuals feel valued, safe, and supported. When this need is met, people develop a stronger sense of belonging, trust, and overall life satisfaction. Nurturance also strengthens communities by promoting mutual aid and cooperation.</p>
+      <div class="scale">
+        <label><input type="radio" name="nurturance" value="1">1</label>
+        <label><input type="radio" name="nurturance" value="2">2</label>
+        <label><input type="radio" name="nurturance" value="3">3</label>
+        <label><input type="radio" name="nurturance" value="4">4</label>
+        <label><input type="radio" name="nurturance" value="5">5</label>
+      </div>
+    </div>
+    <div class="need">
+      <h3>Physical Well-Being</h3>
+      <p class="need-description">The need for adequate nutrition, rest, and exercise to maintain physical health. Physical well-being is the foundation of overall functioning, influencing energy levels, mental clarity, emotional balance, and longevity. When individuals care for their bodies, they enhance their resilience, productivity, and ability to engage fully in life.</p>
+      <div class="scale">
+        <label><input type="radio" name="physical_well_being" value="1">1</label>
+        <label><input type="radio" name="physical_well_being" value="2">2</label>
+        <label><input type="radio" name="physical_well_being" value="3">3</label>
+        <label><input type="radio" name="physical_well_being" value="4">4</label>
+        <label><input type="radio" name="physical_well_being" value="5">5</label>
+      </div>
+    </div>
+    <div class="need">
+      <h3>Safety</h3>
+      <p class="need-description">The need for physical, emotional, and psychological security. Safety allows individuals to express themselves authentically, engage with others without fear of harm or judgment, and develop trust in their relationships and environments. When this need is met, people experience lower stress levels, greater emotional resilience, and the freedom to explore personal growth. A sense of safety is foundational for building confidence, forming deep connections, and maintaining overall well-being.</p>
+      <div class="scale">
+        <label><input type="radio" name="safety" value="1">1</label>
+        <label><input type="radio" name="safety" value="2">2</label>
+        <label><input type="radio" name="safety" value="3">3</label>
+        <label><input type="radio" name="safety" value="4">4</label>
+        <label><input type="radio" name="safety" value="5">5</label>
+      </div>
+    </div>
+    <div class="need">
+      <h3>Trust</h3>
+      <p class="need-description">The need to have confidence in oneself and others. Trust forms the basis of healthy relationships, enabling vulnerability, cooperation, and deeper connections. It is fundamental in personal relationships, workplaces, and communities, as it fosters stability, predictability, and mutual respect. When trust is present, individuals feel safe enough to express themselves, take risks, and rely on others without fear of betrayal or disappointment.</p>
+      <div class="scale">
+        <label><input type="radio" name="trust" value="1">1</label>
+        <label><input type="radio" name="trust" value="2">2</label>
+        <label><input type="radio" name="trust" value="3">3</label>
+        <label><input type="radio" name="trust" value="4">4</label>
+        <label><input type="radio" name="trust" value="5">5</label>
+      </div>
+    </div>
+    <div class="need">
+      <h3>Peace</h3>
+      <p class="need-description">The need for harmony and tranquility. Peace provides emotional stability, clarity, and resilience, helping individuals navigate life's challenges with a sense of calm and purpose. When this need is met, individuals experience reduced stress, improved mental and physical health, and greater patience and compassion. Peace fosters cooperation, deepens relationships, and enhances problem-solving by promoting clear-headed thinking and emotional balance.</p>
+      <div class="scale">
+        <label><input type="radio" name="peace" value="1">1</label>
+        <label><input type="radio" name="peace" value="2">2</label>
+        <label><input type="radio" name="peace" value="3">3</label>
+        <label><input type="radio" name="peace" value="4">4</label>
+        <label><input type="radio" name="peace" value="5">5</label>
+      </div>
+    </div>
+    <div class="need">
+      <h3>Connection</h3>
+      <p class="need-description">The need to feel emotionally bonded and close to others. Connection provides a sense of belonging and security, fostering intimacy and cooperation. When this need is met, individuals experience greater emotional well-being, reduced stress, and improved resilience. Strong social bonds enhance trust, collaboration, and even physical health, as supportive relationships have been shown to lower blood pressure, boost immunity, and increase longevity.</p>
+      <div class="scale">
+        <label><input type="radio" name="connection" value="1">1</label>
+        <label><input type="radio" name="connection" value="2">2</label>
+        <label><input type="radio" name="connection" value="3">3</label>
+        <label><input type="radio" name="connection" value="4">4</label>
+        <label><input type="radio" name="connection" value="5">5</label>
+      </div>
+    </div>
+    <div class="need">
+      <h3>Respect</h3>
+      <p class="need-description">The need to be treated with dignity and consideration. Respect acknowledges an individual’s worth and validates their perspectives, fostering mutual understanding and harmony. When this need is met, people feel valued, heard, and empowered. Respect strengthens relationships, builds self-confidence, and creates a culture of trust and cooperation. It also plays a crucial role in conflict resolution, helping individuals engage in open, meaningful dialogue rather than resorting to defensiveness or hostility.</p>
+      <div class="scale">
+        <label><input type="radio" name="respect" value="1">1</label>
+        <label><input type="radio" name="respect" value="2">2</label>
+        <label><input type="radio" name="respect" value="3">3</label>
+        <label><input type="radio" name="respect" value="4">4</label>
+        <label><input type="radio" name="respect" value="5">5</label>
+      </div>
+    </div>
+    <div class="need">
+      <h3>Understanding</h3>
+      <p class="need-description">The need to be heard and comprehended by others. Understanding fosters empathy, which facilitates effective communication, strengthens relationships, and improves problem-solving. When this need is met, individuals feel valued, respected, and emotionally secure. Misunderstandings and conflicts decrease, and deeper connections are formed, making interactions more meaningful and productive.</p>
+      <div class="scale">
+        <label><input type="radio" name="understanding" value="1">1</label>
+        <label><input type="radio" name="understanding" value="2">2</label>
+        <label><input type="radio" name="understanding" value="3">3</label>
+        <label><input type="radio" name="understanding" value="4">4</label>
+        <label><input type="radio" name="understanding" value="5">5</label>
+      </div>
+    </div>
+    <div class="need">
+      <h3>Autonomy</h3>
+      <p class="need-description">The need for independence and self-determination. Autonomy empowers individuals to make choices aligned with their values and goals, fostering personal growth, fulfillment, and a sense of control over one’s life. When autonomy is met, individuals feel more confident, motivated, and capable of shaping their own destinies. It also promotes creativity, self-reliance, and personal responsibility.</p>
+      <div class="scale">
+        <label><input type="radio" name="autonomy" value="1">1</label>
+        <label><input type="radio" name="autonomy" value="2">2</label>
+        <label><input type="radio" name="autonomy" value="3">3</label>
+        <label><input type="radio" name="autonomy" value="4">4</label>
+        <label><input type="radio" name="autonomy" value="5">5</label>
+      </div>
+    </div>
+    <div class="need">
+      <h3>Love</h3>
+      <p class="need-description">The need for affection, care, and emotional connection. Love nurtures empathy, compassion, and resilience, enhancing well-being and satisfaction in relationships. Feeling loved provides a sense of belonging and security, reduces stress, and improves emotional health. Love exists in many forms, including romantic, familial, platonic, and self-love. When this need is met, individuals develop stronger bonds, increased emotional resilience, and a deeper sense of fulfillment.</p>
+      <div class="scale">
+        <label><input type="radio" name="love" value="1">1</label>
+        <label><input type="radio" name="love" value="2">2</label>
+        <label><input type="radio" name="love" value="3">3</label>
+        <label><input type="radio" name="love" value="4">4</label>
+        <label><input type="radio" name="love" value="5">5</label>
+      </div>
+    </div>
+    <div class="need">
+      <h3>Belonging</h3>
+      <p class="need-description">The need to feel accepted and included in social groups. Belonging provides a sense of identity and community, promoting emotional support, cooperation, and well-being. When this need is met, individuals feel valued, understood, and connected to something greater than themselves. A strong sense of belonging fosters resilience, reduces loneliness, and enhances overall life satisfaction.</p>
+      <div class="scale">
+        <label><input type="radio" name="belonging" value="1">1</label>
+        <label><input type="radio" name="belonging" value="2">2</label>
+        <label><input type="radio" name="belonging" value="3">3</label>
+        <label><input type="radio" name="belonging" value="4">4</label>
+        <label><input type="radio" name="belonging" value="5">5</label>
+      </div>
+    </div>
+    <div class="need">
+      <h3>Acceptance</h3>
+      <p class="need-description">The need to be valued and embraced for who one is. Acceptance cultivates self-compassion, self-worth, and emotional security, allowing individuals to form authentic relationships built on trust and empathy. When people feel accepted—both by themselves and others—they experience greater confidence, reduced anxiety, and a deeper sense of belonging. True acceptance fosters inner peace and emotional resilience, empowering individuals to embrace their uniqueness without fear of rejection.</p>
+      <div class="scale">
+        <label><input type="radio" name="acceptance" value="1">1</label>
+        <label><input type="radio" name="acceptance" value="2">2</label>
+        <label><input type="radio" name="acceptance" value="3">3</label>
+        <label><input type="radio" name="acceptance" value="4">4</label>
+        <label><input type="radio" name="acceptance" value="5">5</label>
+      </div>
+    </div>
+    <div class="need">
+      <h3>Empathy</h3>
+      <p class="need-description">The need to understand and share others' feelings and experiences. Empathy allows individuals to connect on a deeper emotional level, fostering compassion, trust, and meaningful relationships. When this need is met, individuals feel seen, heard, and valued, which strengthens social bonds and reduces misunderstandings. Empathy is also essential for effective communication, conflict resolution, and creating a supportive, inclusive environment.</p>
+      <div class="scale">
+        <label><input type="radio" name="empathy" value="1">1</label>
+        <label><input type="radio" name="empathy" value="2">2</label>
+        <label><input type="radio" name="empathy" value="3">3</label>
+        <label><input type="radio" name="empathy" value="4">4</label>
+        <label><input type="radio" name="empathy" value="5">5</label>
+      </div>
+    </div>
+    <div class="need">
+      <h3>Authenticity</h3>
+      <p class="need-description">The need to be genuine and true to oneself. Authenticity allows individuals to embrace who they truly are, rather than conforming to societal expectations or seeking external validation. It fosters self-awareness, confidence, and integrity, leading to deeper, more meaningful connections with others. When this need is met, individuals experience greater fulfillment, mental clarity, and emotional freedom. Living authentically enables people to express themselves honestly and build relationships based on trust and mutual understanding.</p>
+      <div class="scale">
+        <label><input type="radio" name="authenticity" value="1">1</label>
+        <label><input type="radio" name="authenticity" value="2">2</label>
+        <label><input type="radio" name="authenticity" value="3">3</label>
+        <label><input type="radio" name="authenticity" value="4">4</label>
+        <label><input type="radio" name="authenticity" value="5">5</label>
+      </div>
+    </div>
+    <div class="need">
+      <h3>Meaning</h3>
+      <p class="need-description">The need to find purpose and significance in life. Meaning provides direction, motivation, and a sense of fulfillment. It allows individuals to endure hardships with resilience, knowing their actions serve a greater purpose. When this need is met, individuals experience greater satisfaction, inner peace, and a deeper connection to their values and goals. A meaningful life is not defined by external success alone but by how one's actions align with personal beliefs, passions, and contributions to the world.</p>
+      <div class="scale">
+        <label><input type="radio" name="meaning" value="1">1</label>
+        <label><input type="radio" name="meaning" value="2">2</label>
+        <label><input type="radio" name="meaning" value="3">3</label>
+        <label><input type="radio" name="meaning" value="4">4</label>
+        <label><input type="radio" name="meaning" value="5">5</label>
+      </div>
+    </div>
+    <div class="need">
+      <h3>Contribution</h3>
+      <p class="need-description">The need to make a meaningful impact and contribute to the well-being of others. Contribution fosters a sense of purpose, fulfillment, and interconnectedness. When individuals give their time, energy, or resources to something beyond themselves, they experience a greater sense of belonging and significance. Whether through acts of kindness, service, or mentorship, meaningful contribution enhances both personal growth and societal well-being.</p>
+      <div class="scale">
+        <label><input type="radio" name="contribution" value="1">1</label>
+        <label><input type="radio" name="contribution" value="2">2</label>
+        <label><input type="radio" name="contribution" value="3">3</label>
+        <label><input type="radio" name="contribution" value="4">4</label>
+        <label><input type="radio" name="contribution" value="5">5</label>
+      </div>
+    </div>
+    <div class="need">
+      <h3>Play</h3>
+      <p class="need-description">The need for creativity, spontaneity, and enjoyment. Playfulness is not just for children—it is a fundamental aspect of human well-being that relieves stress, fosters creativity, and strengthens emotional connections. Engaging in play improves cognitive flexibility, enhances problem-solving skills, and brings joy to daily life. When individuals prioritize play, they cultivate resilience, strengthen relationships, and increase overall life satisfaction.</p>
+      <div class="scale">
+        <label><input type="radio" name="play" value="1">1</label>
+        <label><input type="radio" name="play" value="2">2</label>
+        <label><input type="radio" name="play" value="3">3</label>
+        <label><input type="radio" name="play" value="4">4</label>
+        <label><input type="radio" name="play" value="5">5</label>
+      </div>
+    </div>
+    <div class="need">
+      <h3>Integrity</h3>
+      <p class="need-description">The need to act in alignment with one's values and principles. Integrity is the foundation of self-respect, trustworthiness, and strong character. When individuals consistently uphold their values, they cultivate authenticity, earn the respect of others, and build meaningful relationships based on honesty. Living with integrity fosters inner peace and resilience, allowing people to navigate challenges without compromising their beliefs.</p>
+      <div class="scale">
+        <label><input type="radio" name="integrity" value="1">1</label>
+        <label><input type="radio" name="integrity" value="2">2</label>
+        <label><input type="radio" name="integrity" value="3">3</label>
+        <label><input type="radio" name="integrity" value="4">4</label>
+        <label><input type="radio" name="integrity" value="5">5</label>
+      </div>
+    </div>
+    <div class="need">
+      <h3>Emotional Well-Being</h3>
+      <p class="need-description">The need for emotional expression, regulation, and support. Emotional well-being is key to resilience, personal growth, and mental health. It allows individuals to cope with life's challenges, develop strong connections with others, and experience a sense of inner peace. Cultivating emotional well-being promotes self-compassion, emotional intelligence, and the ability to manage stress effectively.</p>
+      <div class="scale">
+        <label><input type="radio" name="emotional_well_being" value="1">1</label>
+        <label><input type="radio" name="emotional_well_being" value="2">2</label>
+        <label><input type="radio" name="emotional_well_being" value="3">3</label>
+        <label><input type="radio" name="emotional_well_being" value="4">4</label>
+        <label><input type="radio" name="emotional_well_being" value="5">5</label>
+      </div>
+    </div>
+    <div class="need">
+      <h3>Spiritual Well-Being</h3>
+      <p class="need-description">The need for connection to something greater than oneself and a sense of purpose or meaning in life. Spiritual well-being provides a foundation of inner peace, resilience, and fulfillment. It involves understanding your place in the world, cultivating a sense of belonging, and tapping into sources of guidance, comfort, and inspiration. By nurturing spiritual health, individuals experience a deep sense of purpose, greater emotional regulation, and enhanced capacity to cope with life’s challenges.</p>
+      <div class="scale">
+        <label><input type="radio" name="spiritual_well_being" value="1">1</label>
+        <label><input type="radio" name="spiritual_well_being" value="2">2</label>
+        <label><input type="radio" name="spiritual_well_being" value="3">3</label>
+        <label><input type="radio" name="spiritual_well_being" value="4">4</label>
+        <label><input type="radio" name="spiritual_well_being" value="5">5</label>
+      </div>
+    </div>
     <div style="text-align:center">
       <button type="submit">See My Summary</button>
       <a class="button secondary" href="index.html">Back to Home</a>
@@ -21,22 +240,56 @@
 </div>
 <footer>© <span id="y"></span> LiveLearnDo</footer>
 <script>
-document.getElementById('y').textContent=new Date().getFullYear();
-const form=document.getElementById('surveyForm'); const result=document.getElementById('result');
-form.addEventListener('submit',e=>{
- e.preventDefault();
- const data={}; let missing=[];
- new FormData(form).forEach((v,k)=>data[k]=Number(v));
- form.querySelectorAll('.need').forEach(sec=>{
-   const nm=sec.querySelector('input').name; if(!data[nm]) missing.push(nm);
- });
- if(missing.length){result.style.display='block';result.innerHTML='Please rate all needs.';return;}
- const entries=Object.entries(data).map(([k,v])=>({need:k.replaceAll('_',' '),score:v})).sort((a,b)=>a.score-b.score);
- const lowest=entries.filter(e=>e.score<=3).slice(0,5);
- let html='<div class="success"><strong>Summary saved.</strong></div><ol>';
- if(!lowest.length){html+='<li>All needs rated high — great job!</li>';} 
- else {lowest.forEach(e=>html+=`<li>${e.need}: ${e.score}/5</li>`);}
- html+='</ol>'; result.className='notice success'; result.style.display='block'; result.innerHTML=html; result.scrollIntoView({behavior:'smooth'});
+document.getElementById('y').textContent = new Date().getFullYear();
+const form = document.getElementById('surveyForm');
+const result = document.getElementById('result');
+
+form.addEventListener('submit', event => {
+  event.preventDefault();
+  const data = {};
+  const labels = {};
+  const missing = [];
+
+  new FormData(form).forEach((value, key) => {
+    data[key] = Number(value);
+  });
+
+  form.querySelectorAll('.need').forEach(section => {
+    const input = section.querySelector('input');
+    const name = input.name;
+    labels[name] = section.querySelector('h3').textContent.trim();
+    if (!data[name]) {
+      missing.push(labels[name]);
+    }
+  });
+
+  if (missing.length) {
+    result.style.display = 'block';
+    result.className = 'notice';
+    result.innerHTML = 'Please rate all needs.';
+    return;
+  }
+
+  const entries = Object.entries(data)
+    .map(([key, score]) => ({ key, score, label: labels[key] }))
+    .sort((a, b) => a.score - b.score);
+
+  const lowest = entries.filter(entry => entry.score <= 3).slice(0, 5);
+
+  let html = '<div class="success"><strong>Summary saved.</strong></div><ol>';
+  if (!lowest.length) {
+    html += '<li>All needs rated high — great job!</li>';
+  } else {
+    lowest.forEach(entry => {
+      html += `<li>${entry.label}: ${entry.score}/5</li>`;
+    });
+  }
+  html += '</ol>';
+
+  result.className = 'notice success';
+  result.style.display = 'block';
+  result.innerHTML = html;
+  result.scrollIntoView({ behavior: 'smooth' });
 });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- expand the survey to cover a fuller set of needs with rich descriptions and updated rating inputs
- enhance the client-side summary to use the displayed need names and handle the expanded form
- refresh the need card styling to better present headings and descriptive text

## Testing
- Manual UI review of survey.html

------
https://chatgpt.com/codex/tasks/task_e_68dae9a44318832b968e596067b74b78